### PR TITLE
Fixes typo in meta file, bumps version

### DIFF
--- a/srfi-127.meta
+++ b/srfi-127.meta
@@ -11,7 +11,7 @@
         "srfi-127.meta"
         "srfi-127.release-info"
         "LICENSE"
-        "README.md")
+        "README.org")
 
  (license "BSD")
  (category data)

--- a/srfi-127.meta
+++ b/srfi-127.meta
@@ -3,7 +3,7 @@
 ((egg "srfi-127.egg")
  ; List of files that should be bundled alongside egg
  (files "lseqs/lseqs.scm"
-        "lseqs/lseqs-test.scm"
+        "lseqs/lseqs-impl.scm"
         "lseqs/r7rs-shim.scm"
         "lseqs/lseqs-test.scm"
         "tests/run.scm"

--- a/srfi-127.release-info
+++ b/srfi-127.release-info
@@ -1,3 +1,4 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "1.1")
 (release "1.0")

--- a/srfi-127.setup
+++ b/srfi-127.setup
@@ -9,4 +9,4 @@
 (install-extension
  'srfi-127
  `(,(dynld-name "srfi-127") ,(dynld-name "srfi-127.import"))
- '((version "1.0")))
+ '((version "1.1")))


### PR DESCRIPTION
Hey Arthur, this bumps the version for the CHICKEN module to reflect the README changes, as well as fixes a typo in the meta file. 

Please add a tag `CHICKEN-1.1` for this. 
