### PR TITLE
Removes hardcoded .so extension

### DIFF
--- a/srfi-127.release-info
+++ b/srfi-127.release-info
@@ -1,4 +1,5 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "1.2")
 (release "1.1")
 (release "1.0")

--- a/srfi-127.setup
+++ b/srfi-127.setup
@@ -3,10 +3,10 @@
 (define (dynld-name fn)
   (make-pathname #f fn ##sys#load-dynamic-extension))
 
-(compile -O3 -d0 -s -J "lseqs/lseqs.scm" -o srfi-127.so)
+(compile -O3 -d0 -s -J "lseqs/lseqs.scm" -o ,(dynld-name "srfi-127"))
 (compile -O2 -d0 -s "srfi-127.import.scm")
 
 (install-extension
  'srfi-127
  `(,(dynld-name "srfi-127") ,(dynld-name "srfi-127.import"))
- '((version "1.1")))
+ '((version "1.2")))


### PR DESCRIPTION
Also bumps version to reflect this change.

Pointed out by Mario Goulart, this hardcoded file extension could cause issues (although on my tests with Windows, did nothing).

As with the others, could you create a tag `CHICKEN-1.2` for this release?
