### PR TITLE
Fixes typo in docs for lseq-every

### DIFF
--- a/srfi-127.html
+++ b/srfi-127.html
@@ -513,7 +513,7 @@ satisfy the predicate <var>pred</var>, and returns the rest of the lseq.</p>
     If an application returns a false value, <code>lseq-any</code> immediately returns
     that value. Otherwise, it iterates until a false value is produced or one of the lseqs runs
     out of values; in
-    the latter case, <code>lseq-any</code> returns the last value returned by <var>pred</var>,
+    the latter case, <code>lseq-every</code> returns the last value returned by <var>pred</var>,
     or <code>#t</code> if <var>pred</var> was never invoked.
     It is an error if <i>pred</i> does not
     accept the same number of arguments as there are <i>lseqs</i> and return a boolean result.

--- a/srfi-127.html
+++ b/srfi-127.html
@@ -510,7 +510,7 @@ satisfy the predicate <var>pred</var>, and returns the rest of the lseq.</p>
 </dt><dd class="proc-def">
     <p>Applies <var>pred</var> to successive elements of the lseqs, returning true if the predicate
     returns true on every application.
-    If an application returns a false value, <code>lseq-any</code> immediately returns
+    If an application returns a false value, <code>lseq-every</code> immediately returns
     that value. Otherwise, it iterates until a false value is produced or one of the lseqs runs
     out of values; in
     the latter case, <code>lseq-every</code> returns the last value returned by <var>pred</var>,

--- a/srfi-127.release-info
+++ b/srfi-127.release-info
@@ -1,5 +1,5 @@
 (uri meta-file
-     "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+     "https://raw.githubusercontent.com/ThatGeoGuy/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
 (release "1.2")
 (release "1.1")
 (release "1.0")


### PR DESCRIPTION
Hi Arthur, 

While reading through the API docs and copying them over to the CHICKEN wiki, I noticed a typo referring to lseq-every as lseq-any. The fix is small, so I applied it.

Cheers, 
