### PR TITLE
Implement lseq-for-each directly.

### DIFF
--- a/lseqs/lseqs-impl.scm
+++ b/lseqs/lseqs-impl.scm
@@ -146,9 +146,23 @@
 (define (lseq-zip . lseqs) (apply lseq-map list lseqs))
 
 ;; Eagerly apply a proc to the elements of lseqs
-;; Included because it's a common operation, even though it is trivial
-(define (lseq-for-each proc . lseqs)
-  (apply for-each proc (map lseq-realize lseqs)))
+(define lseq-for-each
+  (case-lambda
+    ((proc) (error "lseq-for-each: missing arguments"))
+    ((proc lseq)              ; 1-sequence fast path
+     (let loop ((lseq lseq))
+       (if (null? lseq)
+         (if #f #f)
+         (begin
+          (proc (lseq-car lseq))
+          (loop (lseq-cdr lseq))))))
+    ((proc . lseqs)           ; variadic path
+     (let loop ((lseqs lseqs))
+       (if (any-null? lseqs)
+         (if #f #f)
+         (begin
+          (apply proc (map lseq-car lseqs))
+          (loop (map lseq-cdr lseqs))))))))
 
 ;; Filter an lseq lazily to include only elements that satisfy pred
 (define (lseq-filter pred lseq)


### PR DESCRIPTION
Fully forcing lseq-for-each's lseq arguments wastes memory and causes side effects to occur in an unexpected order. This commit provides a new implementation that doesn’t use lseq-realize.